### PR TITLE
Add path parameters

### DIFF
--- a/Sources/PathParameterSupport.swift
+++ b/Sources/PathParameterSupport.swift
@@ -19,6 +19,13 @@ func toFunction(_ handler: @escaping (RequestType, String, ResponseType) -> (Req
 /// return 567
 
 func extractParameter(from path: String, with template: String) -> String {
+  let z = splitAndZip(path: path, route: template)
+  for (pathComp, templateComp) in z {
+    guard templateComp == "*" else {
+      continue
+    }
+    return pathComp
+  }
   return ""
 }
 

--- a/Sources/PathParameterSupport.swift
+++ b/Sources/PathParameterSupport.swift
@@ -1,32 +1,56 @@
 import TitanCore
 
-public extension Titan {
-  public func get(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(pathTemplate.wildcards == 1)
-    self.get(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+func toFunction(_ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType), with pathTemplate: String) -> Function {
+  return { req, res in
+    let param = extractParameters(from: req.path, with: pathTemplate)
+    return handler(req, param[0], res)
   }
 }
 
-func toFunction(_ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType), with pathTemplate: String) -> Function {
+func toFunction(_ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType), with pathTemplate: String) -> Function {
   return { req, res in
-    let param = extractParameter(from: req.path, with: pathTemplate)
-    return handler(req, param, res)
+    let param = extractParameters(from: req.path, with: pathTemplate)
+    return handler(req, param[0], param[1], res)
+  }
+}
+
+func toFunction(_ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType), with pathTemplate: String) -> Function {
+  return { req, res in
+    let param = extractParameters(from: req.path, with: pathTemplate)
+    return handler(req, param[0], param[1], param[2], res)
+  }
+}
+
+func toFunction(_ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType), with pathTemplate: String) -> Function {
+  return { req, res in
+    let param = extractParameters(from: req.path, with: pathTemplate)
+    return handler(req, param[0], param[1], param[2], param[3], res)
+  }
+}
+
+func toFunction(_ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType), with pathTemplate: String) -> Function {
+  return { req, res in
+    let param = extractParameters(from: req.path, with: pathTemplate)
+    return handler(req, param[0], param[1], param[2], param[3], param[4], res)
   }
 }
 
 /// Where the `path` is /users/567/email
 /// Where the `template` is /users/*/email
-/// return 567
+/// return [567]
 
-func extractParameter(from path: String, with template: String) -> String {
-  let z = splitAndZip(path: path, route: template)
+func extractParameters(from path: String, with template: String) -> [String] {
+  let pathComps = path.splitOnSlashes()
+  let templateComps = template.splitOnSlashes()
+  let z = zip(pathComps, templateComps)
+  var ret: [String] = []
   for (pathComp, templateComp) in z {
     guard templateComp == "*" else {
       continue
     }
-    return pathComp
+    ret.append(pathComp)
   }
-  return ""
+  return ret
 }
 
 extension String {

--- a/Sources/PathParameterSupport.swift
+++ b/Sources/PathParameterSupport.swift
@@ -1,0 +1,36 @@
+import TitanCore
+
+public extension Titan {
+  public func get(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.get(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+}
+
+func toFunction(_ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType), with pathTemplate: String) -> Function {
+  return { req, res in
+    let param = extractParameter(from: req.path, with: pathTemplate)
+    return handler(req, param, res)
+  }
+}
+
+/// Where the `path` is /users/567/email
+/// Where the `template` is /users/*/email
+/// return 567
+
+func extractParameter(from path: String, with template: String) -> String {
+  return ""
+}
+
+extension String {
+
+  var wildcards: Int {
+    return self.characters.reduce(0) { (count, char) in
+      if char == "*" {
+        return count + 1
+      } else {
+        return count
+      }
+    }
+  }
+}

--- a/Sources/TitanFunctionOverloads.generated.swift
+++ b/Sources/TitanFunctionOverloads.generated.swift
@@ -2,98 +2,65 @@ import TitanCore
 
 // Overload all Titan instance methods which take a `Function` to take mutable overloads.
 
-extension Titan {
-
-
-
-
- public func get(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.get(path: path, handler: toFunction(handler))
-}
- public func get(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.get(path: path, handler: toFunction(handler))
-}
-
-
-
- public func post(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.post(path: path, handler: toFunction(handler))
-}
- public func post(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.post(path: path, handler: toFunction(handler))
-}
-
-
-
- public func put(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.put(path: path, handler: toFunction(handler))
-}
- public func put(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.put(path: path, handler: toFunction(handler))
-}
-
-
-
- public func patch(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.patch(path: path, handler: toFunction(handler))
-}
- public func patch(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.patch(path: path, handler: toFunction(handler))
-}
-
-
-
- public func delete(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.delete(path: path, handler: toFunction(handler))
-}
- public func delete(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.delete(path: path, handler: toFunction(handler))
-}
-
-
-
- public func options(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.options(path: path, handler: toFunction(handler))
-}
- public func options(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.options(path: path, handler: toFunction(handler))
-}
-
-
-
- public func head(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.head(path: path, handler: toFunction(handler))
-}
- public func head(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.head(path: path, handler: toFunction(handler))
-}
-
-
-
- public func route(method: String?, path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.route(method: method, path: path, handler: toFunction(handler))
-}
- public func route(method: String?, path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.route(method: method, path: path, handler: toFunction(handler))
-}
-
-
-
- public func addFunction(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.addFunction(path: path, handler: toFunction(handler))
-}
- public func addFunction(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.addFunction(path: path, handler: toFunction(handler))
-}
-
-
-
- public func allMethods(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
-  self.allMethods(path: path, handler: toFunction(handler))
-}
- public func allMethods(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
-  self.allMethods(path: path, handler: toFunction(handler))
-}
-
-
+extension Titan { 
+  public func get(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.get(path: path, handler: toFunction(handler))
+  }
+  public func get(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.get(path: path, handler: toFunction(handler))
+  }
+  public func post(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.post(path: path, handler: toFunction(handler))
+  }
+  public func post(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.post(path: path, handler: toFunction(handler))
+  }
+  public func put(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.put(path: path, handler: toFunction(handler))
+  }
+  public func put(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.put(path: path, handler: toFunction(handler))
+  }
+  public func patch(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.patch(path: path, handler: toFunction(handler))
+  }
+  public func patch(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.patch(path: path, handler: toFunction(handler))
+  }
+  public func delete(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.delete(path: path, handler: toFunction(handler))
+  }
+  public func delete(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.delete(path: path, handler: toFunction(handler))
+  }
+  public func options(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.options(path: path, handler: toFunction(handler))
+  }
+  public func options(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.options(path: path, handler: toFunction(handler))
+  }
+  public func head(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.head(path: path, handler: toFunction(handler))
+  }
+  public func head(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.head(path: path, handler: toFunction(handler))
+  }
+  public func route(method: String?, path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.route(method: method, path: path, handler: toFunction(handler))
+  }
+  public func route(method: String?, path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.route(method: method, path: path, handler: toFunction(handler))
+  }
+  public func addFunction(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.addFunction(path: path, handler: toFunction(handler))
+  }
+  public func addFunction(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.addFunction(path: path, handler: toFunction(handler))
+  }
+  public func allMethods(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
+    self.allMethods(path: path, handler: toFunction(handler))
+  }
+  public func allMethods(path: String, handler: @escaping (inout Request, inout Response) -> (RequestType, ResponseType)) {
+    self.allMethods(path: path, handler: toFunction(handler))
+  }
 }

--- a/Sources/TitanFunctionOverloads.generated.swift
+++ b/Sources/TitanFunctionOverloads.generated.swift
@@ -5,6 +5,8 @@ import TitanCore
 extension Titan {
 
 
+
+
  public func get(path: String, handler: @escaping (inout Request, inout Response) -> Void) {
   self.get(path: path, handler: toFunction(handler))
 }

--- a/Sources/TitanInstanceMethodsNoLabels.generated.swift
+++ b/Sources/TitanInstanceMethodsNoLabels.generated.swift
@@ -3,6 +3,10 @@ import TitanCore
 // Routing methods for Titan overloaded with no labels
 extension Titan {
 
+  public func get(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.get(pathTemplate: pathTemplate, handler: handler)
+  }
+
   public func get(_ path: String, _ handler: @escaping (inout Request, inout Response) -> Void) {
     self.get(path: path, handler: handler)
   }

--- a/Sources/TitanInstanceMethodsNoLabels.generated.swift
+++ b/Sources/TitanInstanceMethodsNoLabels.generated.swift
@@ -3,10 +3,6 @@ import TitanCore
 // Routing methods for Titan overloaded with no labels
 extension Titan {
 
-  public func get(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    self.get(pathTemplate: pathTemplate, handler: handler)
-  }
-
   public func get(_ path: String, _ handler: @escaping (inout Request, inout Response) -> Void) {
     self.get(path: path, handler: handler)
   }
@@ -113,6 +109,146 @@ extension Titan {
 
   public func head(_ path: String, _ handler: @escaping Function) {
     self.head(path: path, handler: handler)
+  }
+
+  public func get(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.get(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func get(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.get(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func get(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.get(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func get(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.get(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func get(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.get(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func post(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.post(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func post(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.post(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func post(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.post(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func post(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.post(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func post(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.post(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func put(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.put(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func put(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.put(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func put(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.put(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func put(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.put(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func put(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.put(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func patch(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.patch(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func patch(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.patch(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func patch(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.patch(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func patch(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.patch(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func patch(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.patch(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func delete(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.delete(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func delete(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.delete(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func delete(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.delete(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func delete(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.delete(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func delete(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.delete(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func options(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.options(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func options(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.options(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func options(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.options(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func options(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.options(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func options(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.options(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func head(_ pathTemplate: String, _ handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.head(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func head(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.head(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func head(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.head(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func head(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.head(pathTemplate: pathTemplate, handler: handler)
+  }
+
+  public func head(_ pathTemplate: String, _ handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    self.head(pathTemplate: pathTemplate, handler: handler)
   }
 
   public func route(_ method: String?, _ path: String, _ handler: @escaping Function) {

--- a/Sources/TitanParameterizedRoutes.generated.swift
+++ b/Sources/TitanParameterizedRoutes.generated.swift
@@ -1,0 +1,154 @@
+import TitanCore
+
+// Extend all route methods to access path components directly
+/*
+extension Titan {
+
+  public func get(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.get(path: path, handler: toFunction(handler))
+  }
+  public func get(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.get(path: path, handler: toFunction(handler))
+  }
+  public func get(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.get(path: path, handler: toFunction(handler))
+  }
+  public func get(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.get(path: path, handler: toFunction(handler))
+  }
+  public func get(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.get(path: path, handler: toFunction(handler))
+  }
+
+  public func post(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.post(path: path, handler: toFunction(handler))
+  }
+  public func post(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.post(path: path, handler: toFunction(handler))
+  }
+  public func post(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.post(path: path, handler: toFunction(handler))
+  }
+  public func post(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.post(path: path, handler: toFunction(handler))
+  }
+  public func post(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.post(path: path, handler: toFunction(handler))
+  }
+
+  public func put(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.put(path: path, handler: toFunction(handler))
+  }
+  public func put(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.put(path: path, handler: toFunction(handler))
+  }
+  public func put(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.put(path: path, handler: toFunction(handler))
+  }
+  public func put(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.put(path: path, handler: toFunction(handler))
+  }
+  public func put(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.put(path: path, handler: toFunction(handler))
+  }
+
+  public func patch(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.patch(path: path, handler: toFunction(handler))
+  }
+  public func patch(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.patch(path: path, handler: toFunction(handler))
+  }
+  public func patch(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.patch(path: path, handler: toFunction(handler))
+  }
+  public func patch(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.patch(path: path, handler: toFunction(handler))
+  }
+  public func patch(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.patch(path: path, handler: toFunction(handler))
+  }
+
+  public func delete(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.delete(path: path, handler: toFunction(handler))
+  }
+  public func delete(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.delete(path: path, handler: toFunction(handler))
+  }
+  public func delete(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.delete(path: path, handler: toFunction(handler))
+  }
+  public func delete(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.delete(path: path, handler: toFunction(handler))
+  }
+  public func delete(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.delete(path: path, handler: toFunction(handler))
+  }
+
+  public func options(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.options(path: path, handler: toFunction(handler))
+  }
+  public func options(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.options(path: path, handler: toFunction(handler))
+  }
+  public func options(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.options(path: path, handler: toFunction(handler))
+  }
+  public func options(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.options(path: path, handler: toFunction(handler))
+  }
+  public func options(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.options(path: path, handler: toFunction(handler))
+  }
+
+  public func head(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.head(path: path, handler: toFunction(handler))
+  }
+  public func head(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.head(path: path, handler: toFunction(handler))
+  }
+  public func head(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.head(path: path, handler: toFunction(handler))
+  }
+  public func head(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.head(path: path, handler: toFunction(handler))
+  }
+  public func head(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.head(path: path, handler: toFunction(handler))
+  }
+
+}*/

--- a/Sources/TitanParameterizedRoutes.generated.swift
+++ b/Sources/TitanParameterizedRoutes.generated.swift
@@ -1,154 +1,154 @@
 import TitanCore
 
 // Extend all route methods to access path components directly
-/*
+
 extension Titan {
 
-  public func get(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.get(path: path, handler: toFunction(handler))
+  public func get(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.get(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func get(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.get(path: path, handler: toFunction(handler))
+  public func get(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.get(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func get(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.get(path: path, handler: toFunction(handler))
+  public func get(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.get(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func get(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.get(path: path, handler: toFunction(handler))
+  public func get(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.get(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func get(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.get(path: path, handler: toFunction(handler))
-  }
-
-  public func post(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.post(path: path, handler: toFunction(handler))
-  }
-  public func post(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.post(path: path, handler: toFunction(handler))
-  }
-  public func post(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.post(path: path, handler: toFunction(handler))
-  }
-  public func post(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.post(path: path, handler: toFunction(handler))
-  }
-  public func post(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.post(path: path, handler: toFunction(handler))
+  public func get(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.get(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
 
-  public func put(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.put(path: path, handler: toFunction(handler))
+  public func post(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.post(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func put(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.put(path: path, handler: toFunction(handler))
+  public func post(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.post(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func put(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.put(path: path, handler: toFunction(handler))
+  public func post(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.post(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func put(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.put(path: path, handler: toFunction(handler))
+  public func post(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.post(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func put(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.put(path: path, handler: toFunction(handler))
-  }
-
-  public func patch(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.patch(path: path, handler: toFunction(handler))
-  }
-  public func patch(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.patch(path: path, handler: toFunction(handler))
-  }
-  public func patch(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.patch(path: path, handler: toFunction(handler))
-  }
-  public func patch(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.patch(path: path, handler: toFunction(handler))
-  }
-  public func patch(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.patch(path: path, handler: toFunction(handler))
+  public func post(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.post(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
 
-  public func delete(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.delete(path: path, handler: toFunction(handler))
+  public func put(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.put(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func delete(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.delete(path: path, handler: toFunction(handler))
+  public func put(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.put(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func delete(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.delete(path: path, handler: toFunction(handler))
+  public func put(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.put(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func delete(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.delete(path: path, handler: toFunction(handler))
+  public func put(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.put(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func delete(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.delete(path: path, handler: toFunction(handler))
-  }
-
-  public func options(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.options(path: path, handler: toFunction(handler))
-  }
-  public func options(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.options(path: path, handler: toFunction(handler))
-  }
-  public func options(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.options(path: path, handler: toFunction(handler))
-  }
-  public func options(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.options(path: path, handler: toFunction(handler))
-  }
-  public func options(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.options(path: path, handler: toFunction(handler))
+  public func put(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.put(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
 
-  public func head(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.head(path: path, handler: toFunction(handler))
+  public func patch(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.patch(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func head(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.head(path: path, handler: toFunction(handler))
+  public func patch(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.patch(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func head(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.head(path: path, handler: toFunction(handler))
+  public func patch(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.patch(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func head(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.head(path: path, handler: toFunction(handler))
+  public func patch(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.patch(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func head(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.head(path: path, handler: toFunction(handler))
+  public func patch(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.patch(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
 
-}*/
+  public func delete(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.delete(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func delete(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.delete(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func delete(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.delete(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func delete(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.delete(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func delete(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.delete(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+
+  public func options(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.options(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func options(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.options(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func options(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.options(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func options(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.options(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func options(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.options(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+
+  public func head(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.head(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func head(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.head(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func head(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.head(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func head(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.head(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+  public func head(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.head(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
+  }
+
+}

--- a/Sources/TitanRoutingExtension.swift
+++ b/Sources/TitanRoutingExtension.swift
@@ -29,7 +29,21 @@ extension Titan {
 
 }
 
+/// Match a given path with a route. Segments containing an asterisk are treated as wild.
 private func matchRoute(path: String, route: String) -> Bool {
   guard route != "*" else { return true }
-  return path == route
+  guard route.wildcards != 0 else {
+    return path == route
+  }
+  let splitRoute = route.characters.split(separator: "/").map { String($0) }
+  let splitPath = path.characters.split(separator: "/").map { String($0) }
+  let zipped = zip(splitRoute, splitPath)
+  for (routeSegment, pathSegment) in zipped {
+    if (routeSegment != pathSegment) && (routeSegment != "*") {
+      return false
+    } else {
+      continue
+    }
+  }
+  return true
 }

--- a/Sources/TitanRoutingExtension.swift
+++ b/Sources/TitanRoutingExtension.swift
@@ -35,10 +35,8 @@ private func matchRoute(path: String, route: String) -> Bool {
   guard route.wildcards != 0 else {
     return path == route
   }
-  let splitRoute = route.characters.split(separator: "/").map { String($0) }
-  let splitPath = path.characters.split(separator: "/").map { String($0) }
-  let zipped = zip(splitRoute, splitPath)
-  for (routeSegment, pathSegment) in zipped {
+  let zipped = splitAndZip(path: path, route: route)
+  for (pathSegment, routeSegment) in zipped {
     if (routeSegment != pathSegment) && (routeSegment != "*") {
       return false
     } else {
@@ -46,4 +44,10 @@ private func matchRoute(path: String, route: String) -> Bool {
     }
   }
   return true
+}
+
+func splitAndZip(path: String, route: String) -> Zip2Sequence<[String], [String]>  {
+  let splitRoute = route.characters.split(separator: "/").map { String($0) }
+  let splitPath = path.characters.split(separator: "/").map { String($0) }
+  return zip(splitPath, splitRoute)
 }

--- a/Templates/TitanFunctionOverloads.stencil
+++ b/Templates/TitanFunctionOverloads.stencil
@@ -2,15 +2,11 @@ import TitanCore
 
 // Overload all Titan instance methods which take a `Function` to take mutable overloads.
 
-extension Titan {
-{% for method in type.Titan.methods %}
-{% if method.parameters.last.typeName.name == "@escaping Function" %}
- public func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != param.name %}{{ param.argumentLabel }} {% endif %}{{ param.name }}: {% if param.typeName.name != "@escaping Function" %}{{ param.typeName }}{% else %}@escaping (inout Request, inout Response) -> Void{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}) {
-  self.{{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != "_" %}{{ param.argumentLabel }}: {% endif %}{% if param.typeName.name != "@escaping Function" %}{{ param.name }}{% else %}toFunction({{param.name}}){% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})
-}
- public func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != param.name %}{{ param.argumentLabel }} {% endif %}{{ param.name }}: {% if param.typeName.name != "@escaping Function" %}{{ param.typeName }}{% else %}@escaping (inout Request, inout Response) -> (RequestType, ResponseType){% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}) {
-  self.{{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != "_" %}{{ param.argumentLabel }}: {% endif %}{% if param.typeName.name != "@escaping Function" %}{{ param.name }}{% else %}toFunction({{param.name}}){% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})
-}
-{% endif %}
-{% endfor %}
+extension Titan { {% for method in type.Titan.methods %}{% if method.parameters.last.typeName.name == "@escaping Function" %}
+  public func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != param.name %}{{ param.argumentLabel }} {% endif %}{{ param.name }}: {% if param.typeName.name != "@escaping Function" %}{{ param.typeName }}{% else %}@escaping (inout Request, inout Response) -> Void{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}) {
+    self.{{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != "_" %}{{ param.argumentLabel }}: {% endif %}{% if param.typeName.name != "@escaping Function" %}{{ param.name }}{% else %}toFunction({{param.name}}){% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})
+  }
+  public func {{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != param.name %}{{ param.argumentLabel }} {% endif %}{{ param.name }}: {% if param.typeName.name != "@escaping Function" %}{{ param.typeName }}{% else %}@escaping (inout Request, inout Response) -> (RequestType, ResponseType){% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}) {
+    self.{{ method.shortName }}({% for param in method.parameters %}{% if param.argumentLabel != "_" %}{{ param.argumentLabel }}: {% endif %}{% if param.typeName.name != "@escaping Function" %}{{ param.name }}{% else %}toFunction({{param.name}}){% endif %}{% if not forloop.last %}, {% endif %}{% endfor %})
+  }{% endif %}{% endfor %}
 }

--- a/Templates/TitanParameterizedRoutes.stencil
+++ b/Templates/TitanParameterizedRoutes.stencil
@@ -1,28 +1,28 @@
 import TitanCore
 
 // Extend all route methods to access path components directly
-/*
+
 extension Titan {
 {% for method in type.HTTPMethod.cases %}
-  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 1)
-    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  public func {{method.name | lowercase}}(pathTemplate: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 1)
+    self.{{method.name | lowercase}}(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 2)
-    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  public func {{method.name | lowercase}}(pathTemplate: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 2)
+    self.{{method.name | lowercase}}(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 3)
-    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  public func {{method.name | lowercase}}(pathTemplate: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 3)
+    self.{{method.name | lowercase}}(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 4)
-    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  public func {{method.name | lowercase}}(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 4)
+    self.{{method.name | lowercase}}(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
-  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
-    precondition(path.wildcards == 5)
-    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  public func {{method.name | lowercase}}(pathTemplate: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(pathTemplate.wildcards == 5)
+    self.{{method.name | lowercase}}(path: pathTemplate, handler: toFunction(handler, with: pathTemplate))
   }
 {% endfor %}
-}*/
+}

--- a/Templates/TitanParameterizedRoutes.stencil
+++ b/Templates/TitanParameterizedRoutes.stencil
@@ -1,0 +1,28 @@
+import TitanCore
+
+// Extend all route methods to access path components directly
+/*
+extension Titan {
+{% for method in type.HTTPMethod.cases %}
+  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 1)
+    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  }
+  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 2)
+    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  }
+  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 3)
+    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  }
+  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 4)
+    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  }
+  public func {{method.name | lowercase}}(path: String, handler: @escaping (RequestType, String, String, String, String, String, ResponseType) -> (RequestType, ResponseType)) {
+    precondition(path.wildcards == 5)
+    self.{{method.name | lowercase}}(path: path, handler: toFunction(handler))
+  }
+{% endfor %}
+}*/

--- a/Tests/TitanRouterTests/TitanRouterTests.swift
+++ b/Tests/TitanRouterTests/TitanRouterTests.swift
@@ -169,4 +169,20 @@ final class TitanRouterTests: XCTestCase {
     let resp = app.app(request: Request("GET", "/foo/567/baz"))
     XCTAssertEqual(resp.body, "567")
   }
+
+  func testTypesafeMultipleParams() {
+    app.get(pathTemplate: "/foo/*/bar/*/baz/*/qux/*/yex/*") { req, foo, bar, baz, qux, yex, res in
+      return (req, Response("foo=\(foo), bar=\(bar), baz=\(baz), qux=\(qux), yex=\(yex)"))
+    }
+    let resp = app.app(request: Request("GET", "/foo/hello/bar/world/baz/my/qux/name/yex/is"))
+    XCTAssertEqual(resp.body, "foo=hello, bar=world, baz=my, qux=name, yex=is")
+  }
+
+  func testMismatchingLongPaths() {
+    app.get(path: "/foo/*/thing") { req, res in
+      return (req, Response(200, "Got foo"))
+    }
+    let resp = app.app(request: Request("GET", "/foo/bar"))
+    XCTAssertNotEqual(resp.body, "Got foo")
+  }
 }

--- a/Tests/TitanRouterTests/TitanRouterTests.swift
+++ b/Tests/TitanRouterTests/TitanRouterTests.swift
@@ -153,4 +153,20 @@ final class TitanRouterTests: XCTestCase {
     XCTAssertEqual(resp.code, 201)
     XCTAssertEqual(app.app(request: Request("GET", "/username")).body, "Lisa")
   }
+
+  func testMatchingWildcardComponents() {
+    app.get("/foo/*/baz/*/bar") { req, res in
+      return (req, Response(200, ""))
+    }
+    let resp = app.app(request: Request("GET", "/foo/123456/baz/7890/bar"))
+    XCTAssertEqual(resp.code, 200)
+  }
+
+  func testTypesafePathParams() {
+    app.get(pathTemplate: "/foo/*/baz") { req, id, res in
+      return (req, Response(id))
+    }
+    let resp = app.app(request: Request("GET", "/foo/567/baz"))
+    XCTAssertEqual(resp.body, "567")
+  }
 }

--- a/script/generate.sh
+++ b/script/generate.sh
@@ -25,7 +25,7 @@ enum HTTPMethod {
 }
 EOD
 
-for file in "TitanInstanceRoutesByMethod" "TitanFunctionOverloads" "TitanInstanceMethodsNoLabels"
+for file in "TitanInstanceRoutesByMethod" "TitanParameterizedRoutes" "TitanFunctionOverloads" "TitanInstanceMethodsNoLabels"
 do
   .build/debug/sourcery Sources/ Templates/$file.stencil Sources/ # Generate source code
   tail -n +4 Sources/$file.generated.swift > Sources/$file.generated.swift.temp # Trim first three lines of generated file into temp file


### PR DESCRIPTION
You can now write:

```swift
app.get("/foo/*/bar") { req, param, res in
// do something with the * – in 'param'
return (req, res)
}
```

Currently only supports up to five params, but framework is there for n-length params.

I consider this a basic version of routing – I think it's enough for the time being, for a v1, and I expect after the open source release to see people contribute cool advancements (e.g. named variables).

Or even better, they might write a different router.